### PR TITLE
pass an argument to the onSearchChange callback handler

### DIFF
--- a/SearchBar.js
+++ b/SearchBar.js
@@ -148,7 +148,7 @@ export default class SearchBar extends React.Component {
             returnKeyType={returnKeyType}
             onFocus={this._onFocus}
             onBlur={this._onBlur}
-            onChange={onSearchChange}
+            onChangeText={onSearchChange}
             placeholder={placeholder}
             placeholderTextColor={placeholderColor}
             style={


### PR DESCRIPTION
I think it's better to use onChangeText instead of onChange so that changed text can be passed as an argument to the callback handler.