### PR TITLE
Enable to pass in additional props to TextInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ export default class ExampleComponent extends Component {
 - `returnKeyType`: Optional string, use it to customize the return key type
 - `padding`: Optional string, use it to define a different padding size, default is `5`
 - `inputStyle`: Optional string, use it to pass your style to the `TextInput`
+- `inputProps`: Optional object, use it to pass additional props to the `TextInput`, for example `{autoFocus: true}`
 
 
 The React packager will include the SearchBar component in your app's JS package and make it available for your app to use.

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -42,7 +42,8 @@ export default class SearchBar extends React.Component {
     iconBackName: PropTypes.string,
     placeholderColor: PropTypes.string,
     iconColor: PropTypes.string,
-    textStyle: PropTypes.object
+    textStyle: PropTypes.object,
+    inputProps: PropTypes.object
   }
 
   static defaultProps = {
@@ -170,6 +171,7 @@ export default class SearchBar extends React.Component {
                 textStyle
               ]
             }
+            {...this.props.inputProps}
           />
           {this.state.isOnFocus ?
             <TouchableOpacity onPress={this._onClose}>


### PR DESCRIPTION
I needed to pass additional props to textinput in my project so I added additional prop `inputProps` that does that. This PR also solves #11 

Comment about implementation: I usually prefer more extensibility so I added the props expansion after existing props. But if you prefer the safe side we can put it to the front so it can't overide built-in functionality.