### PR TITLE
Fix incorrect icon sizes, make icon padding configurable, remove extra height

### DIFF
--- a/SearchBar.js
+++ b/SearchBar.js
@@ -116,9 +116,10 @@ export default class SearchBar extends React.Component {
       textStyle
     } = this.props;
 
-    let { iconSize } = this.props
-
+    let { iconSize, iconPadding } = this.props
+    
     iconSize = typeof iconSize !== 'undefined' ? iconSize : height * 0.5
+    iconPadding = typeof iconPadding !== 'undefined' ? iconPadding : height * 0.25
 
     return (
       <View
@@ -130,8 +131,8 @@ export default class SearchBar extends React.Component {
             [
               styles.searchBar,
               {
-                height: height + 10,
-                paddingLeft: height * 0.25,
+                height: height,
+                paddingLeft: iconPadding
               },
               inputStyle
             ]
@@ -140,13 +141,16 @@ export default class SearchBar extends React.Component {
           {this.state.isOnFocus ?
             <TouchableOpacity onPress={this._dismissKeyboard}>
               <Icon
-                name={iconBackName} size={height * 0.5}
+                name={iconBackName}
+                size={iconSize}
+                paddingLeft={iconPadding}
                 color={iconColor}
               />
             </TouchableOpacity>
           :
             <Icon
-              name={iconSearchName} size={height * 0.5}
+              name={iconSearchName}size={iconSize}
+              paddingLeft={iconPadding}
               color={iconColor}
             />
           }
@@ -165,7 +169,7 @@ export default class SearchBar extends React.Component {
             style={
               [styles.searchBarInput,
                 {
-                  paddingLeft: height * 0.5,
+                  paddingLeft: iconPadding,
                   fontSize: height * 0.4,
                 },
                 textStyle
@@ -176,7 +180,7 @@ export default class SearchBar extends React.Component {
           {this.state.isOnFocus ?
             <TouchableOpacity onPress={this._onClose}>
               <Icon
-                style={{paddingRight: height * 0.5 }}
+                style={{paddingRight: iconPadding }}
                 name={iconCloseName} size={iconSize}
                 color={iconColor}
               />

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -99,6 +99,13 @@ export default class SearchBar extends React.Component {
     dismissKeyboard()
   }
 
+  setText(text, focus) {
+    this._textInput.setNativeProps({ text: text });
+    if (focus) {
+      this._onFocus();
+    }
+  }
+
   render() {
     const {
       height,


### PR DESCRIPTION
This PR resolves a few issues:

1) `iconSize` property was not being used on back and search icons (only close).
2) Allow customisable horizontal icon padding with new `iconPadding` property
3) Remove extra ` + 10` added to the search bar. Although this is a breaking change (in that it will change the height of the search bar in existing projects), I think it is worth it. I spent a while trying to figure out why the search bar height did not match that of a wrapping `View` when both of them had the same height value!