### PR TITLE
Option to always show the back button

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ export default class ExampleComponent extends Component {
 
 - `onSearchChange`: Callback on search change
 - `onBackPress`: Optional function, Callback on back icon pressed
+- `alwaysShowBackButton`: Optional bool, use if you want to always show the back button instead of search, default is `false`
 - `iconCloseName`: Optional string, use it to customize the close icon
 - `iconSearchName`: Optional string, use it to customize the search icon
 - `iconBackName`: Optional string, use it to customize the back icon

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -46,6 +46,7 @@ export default class SearchBar extends React.Component {
     textStyle: PropTypes.object,
     inputProps: PropTypes.object,
     onBackPress: PropTypes.func,
+    alwaysShowBackButton: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -62,6 +63,7 @@ export default class SearchBar extends React.Component {
     placeholderColor: '#bdbdbd',
     iconColor: '#737373',
     textStyle: {},
+    alwaysShowBackButton: false,
   };
 
   constructor(props) {
@@ -155,7 +157,7 @@ export default class SearchBar extends React.Component {
             ]
           }
         >
-          {this.state.isOnFocus
+          {this.state.isOnFocus || this.props.alwaysShowBackButton
             ? <TouchableOpacity onPress={this._backPressed.bind(this)}>
                 <Icon
                   name={iconBackName}


### PR DESCRIPTION
Currently right now the search icon is shown by default. When the user focuses the Searchbar the search icon changes to the back button.

This pr adds the `alwaysShowBackButton` prop which allows the back button to be shown at all times.

With this prop combined with the `onBackPress` prop, the Searchbar can be used as a full screen search modal.