### PR TITLE
Replaced React.PropTypes with prop-types package

### DIFF
--- a/SearchBar.js
+++ b/SearchBar.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types'
 import {
   TextInput,
   StyleSheet,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "Material Design"
   ],
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react-native-vector-icons": "^2.0.3"
   },
   "author": "Anand Dayalan",


### PR DESCRIPTION
React.PropTypes was removed in [react 15.5](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes). This PR replaces React.PropTypes with Proptypes from  prop-types package