### PR TITLE
Upgrade react-native-vector-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-native-vector-icons": "^2.0.3"
+    "react-native-vector-icons": "^4.2.0"
   },
   "author": "Anand Dayalan",
   "license": "MIT",


### PR DESCRIPTION
The React.PropTypes fix was made in the last PR #24 . react-native-vector-icons also made this fix, however you're using an older version of the library so the error is still showing.

This PR upgrades the dependency on react-native-vector-icons to get rid of that warning.