### PR TITLE
Use RN Keyboard import to access dismissKeyboard instead of hard path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ export default class ExampleComponent extends Component {
 # Available Props
 
 - `onSearchChange`: Callback on search change
+- `onClear`: Callback when the 'X' button is pressed. This also calls `onSearchChange` with an empty string.
+- `searchValue`: Initializes the input field. Changing this prop does not change the input value.
 - `onBackPress`: Optional function, Callback on back icon pressed
 - `alwaysShowBackButton`: Optional bool, use if you want to always show the back button instead of search, default is `false`
 - `iconCloseName`: Optional string, use it to customize the close icon

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -68,6 +68,7 @@ export default class SearchBar extends React.Component {
     iconColor: '#737373',
     textStyle: {},
     alwaysShowBackButton: false,
+    searchValue: '',
   };
 
   constructor(props) {
@@ -75,18 +76,22 @@ export default class SearchBar extends React.Component {
     this.state = {
       isOnFocus: false,
       wait: true,
+      searchValue: props.searchValue,
     };
+    this._onSearchChange = this._onSearchChange.bind(this);
+    this._onClear = this._onClear.bind(this);
     this._onFocus = this._onFocus.bind(this);
     this._onBlur = this._onBlur.bind(this);
-    this._onClose = this._onClose.bind(this);
   }
 
-  _onClose() {
-    this._textInput.setNativeProps({text: ''});
-    this.props.onSearchChange('');
-    if (this.props.onClose) {
-      this.props.onClose();
-    }
+  _onSearchChange(searchValue) {
+    this.setState({searchValue});
+    this.props.onSearchChange && this.props.onSearchChange(searchValue);
+  }
+
+  _onClear() {
+    this._onSearchChange('');
+    this.props.onClear && this.props.onClear();
   }
 
   _onFocus() {
@@ -123,7 +128,6 @@ export default class SearchBar extends React.Component {
       height,
       autoCorrect,
       returnKeyType,
-      onSearchChange,
       placeholder,
       padding,
       inputStyle,
@@ -184,12 +188,13 @@ export default class SearchBar extends React.Component {
             )
           }
           <TextInput
+            value={this.state.searchValue}
             autoCorrect={autoCorrect === true}
             ref={c => this._textInput = c}
             returnKeyType={returnKeyType}
             onFocus={this._onFocus}
             onBlur={this._onBlur}
-            onChangeText={onSearchChange}
+            onChangeText={this._onSearchChange}
             onEndEditing={this.props.onEndEditing}
             onSubmitEditing={this.props.onSubmitEditing}
             placeholder={placeholder}
@@ -207,7 +212,7 @@ export default class SearchBar extends React.Component {
             {...this.props.inputProps}
           />
           {this.state.isOnFocus ?
-            <TouchableOpacity onPress={this._onClose}>
+            <TouchableOpacity onPress={this._onClear}>
               { iconCloseComponent ?
                 iconCloseComponent
                 :

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -7,9 +7,9 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Text,
+  Keyboard,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
-import dismissKeyboard from 'react-native/Libraries/Utilities/dismissKeyboard';
 
 const styles = StyleSheet.create({
   searchBar: {
@@ -101,15 +101,11 @@ export default class SearchBar extends React.Component {
     if (this.props.onBlur) {
       this.props.onBlur();
     }
-    this._dismissKeyboard();
-  }
-
-  _dismissKeyboard() {
-    dismissKeyboard();
+    Keyboard.dismissKeyboard();
   }
 
   _backPressed() {
-    dismissKeyboard()
+    Keyboard.dismissKeyboard()
     if(this.props.onBackPress) {
       this.props.onBackPress()
     }
@@ -149,7 +145,7 @@ export default class SearchBar extends React.Component {
 
     return (
       <View
-        onStartShouldSetResponder={this._dismissKeyboard}
+        onStartShouldSetResponder={Keyboard.dismissKeyboard}
         style={{padding: padding}}
       >
         <View

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -101,11 +101,11 @@ export default class SearchBar extends React.Component {
     if (this.props.onBlur) {
       this.props.onBlur();
     }
-    Keyboard.dismissKeyboard();
+    Keyboard.dismiss();
   }
 
   _backPressed() {
-    Keyboard.dismissKeyboard()
+    Keyboard.dismiss()
     if(this.props.onBackPress) {
       this.props.onBackPress()
     }
@@ -145,7 +145,7 @@ export default class SearchBar extends React.Component {
 
     return (
       <View
-        onStartShouldSetResponder={Keyboard.dismissKeyboard}
+        onStartShouldSetResponder={Keyboard.dismiss}
         style={{padding: padding}}
       >
         <View


### PR DESCRIPTION
dismissKeyboard() should be accessed through React Native's Keyboard export.  Accessing it through a hard path risks breakage if files are moved.  It also breaks usage with `react-native-web`.